### PR TITLE
Removed depricated module InstanceMethods

### DIFF
--- a/lib/mongoid_vote/voteable.rb
+++ b/lib/mongoid_vote/voteable.rb
@@ -10,7 +10,7 @@ module MongoidVote
       field :vote_count,    :type => Integer, :default => 0
     end
 
-    module InstanceMethods
+
       
       def upvote(user)
         vote_handler(current_vote(user), :up, user)
@@ -71,6 +71,6 @@ module MongoidVote
         self.down_count += down
         self.vote_count += count
       end
-    end
+
   end
 end

--- a/readme.rdoc
+++ b/readme.rdoc
@@ -4,7 +4,7 @@ A basic gem that adds voting capabilities to a Mongoid document. Will work on em
 
 == Installation
 
-=== Rails 3.x
+=== Rails 3.x and above
 
 To install the gem, add this to your Gemfile:
 


### PR DESCRIPTION
removed module InstanceMethods are they are depricated from rails 3.2 to support rails 4 apps.
